### PR TITLE
Revert Fusion Reactor GridLimit

### DIFF
--- a/Storage/2995125400.sbm_BlockRestrictions/BlockRestrictions.cfg
+++ b/Storage/2995125400.sbm_BlockRestrictions/BlockRestrictions.cfg
@@ -14818,7 +14818,7 @@
     <SerializableBlockSetting>
       <Type>MyObjectBuilder_Reactor/Caster_Reactor</Type>
       <PlayerMaxCount>0</PlayerMaxCount>
-      <GridMaxCount>2</GridMaxCount>
+      <GridMaxCount>0</GridMaxCount>
       <FactionMaxCount>0</FactionMaxCount>
       <AllowedForNPC>true</AllowedForNPC>
       <AllowedForPlayer>true</AllowedForPlayer>


### PR DESCRIPTION
Borked efficiency calculation on reactors >2GW has been fixed, returning peace and harmony to the starcoremtworld.